### PR TITLE
Add support for SPI Mode (0-3)

### DIFF
--- a/src/controller/Display.cpp
+++ b/src/controller/Display.cpp
@@ -110,6 +110,7 @@ namespace udd {
 
         printf("spiChannel:        %d\n", config.spiChannel);
         printf("spiSpeed:          %d\n", config.spiSpeed);
+        printf("spiMode:           %d\n", config.spiMode);
 
         printf("handle:            %d\n", handle);
     }
@@ -122,7 +123,7 @@ namespace udd {
         if (handle >= 0) {
             close(handle);
         }
-        handle = wiringPiSPISetup(config.spiChannel, config.spiSpeed);
+        handle = wiringPiSPISetupMode(config.spiChannel, config.spiSpeed, config.spiMode);
     }
 
     void Display::visable() {

--- a/src/controller/Display.h
+++ b/src/controller/Display.h
@@ -39,6 +39,7 @@ namespace udd {
 
         int spiChannel = 0;
         int spiSpeed = 10000000;
+        int spiMode = 0; // SPI mode 0,1,2,3
 
 
 // NeoPixel


### PR DESCRIPTION
wiringPi has supported SPI initialization with mode since v2.24 (February 2015)
This commit adds support for using it via a new `spiMode` member in `DisplayConfigurationStruct`
`spiMode` defaults to zero which was the previous default mode.