### PR TITLE
Fixes & improvements to Image, including scaling

### DIFF
--- a/example/demo1.cpp
+++ b/example/demo1.cpp
@@ -41,7 +41,7 @@ unsigned long long currentTimeMillis() {
 }
 
 
-void drawSine(Image image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
+void drawSine(Image &image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
     bool first = true;;
     int lx = -1, ly = -1;
     double vx = 0;
@@ -62,7 +62,7 @@ void drawSine(Image image, float offset, float speed, int maxX, int maxY, float 
 }
 
 
-bool demoSineWave(int frameCount, long long start, Image image) {
+bool demoSineWave(int frameCount, long long start, Image &image) {
     long long now = currentTimeMillis();
     float refVoltage = 5;
 
@@ -148,6 +148,20 @@ void rotationDemo() {
 
 }
 
+void imageDemo(Image &img) {
+    Image images[] = {
+        img,
+        img.scale(0.75, 0.75, BILINEAR),
+        img.scale(0.50, 0.50, BILINEAR),
+        img.scale(0.25 ,0.25, BILINEAR)
+    };
+    for (int i = 0; i < sizeof(images)/sizeof(img); i++) {
+        Image &thisImg = images[i];
+        d1.showImage(thisImg, DEGREE_270);
+        delay(2000);
+    }
+ }
+
 void display1Demo() {
     printf("demo1\n"); fflush(stdout);
 
@@ -170,8 +184,7 @@ void display1Demo() {
         delay(solidsDelay);
         d1.clearScreen(BLACK);
 
-        d1.showImage(bmp, DEGREE_270);
-        delay(2000);
+        imageDemo(bmp);
 
         rotationDemo();
         delay(4000);
@@ -214,14 +227,6 @@ int main(int argc, char **argv)
     pinMode(11, OUTPUT);
     digitalWrite(10, HIGH);
     digitalWrite(11, HIGH);
-
-    int         demos = 3;
-    pthread_t   threads[demos];
-    char        message[demos][256];
-
-    for (int i = 0; i < demos; ++i) {
-        sprintf(message[i], "demo thread %d", i);
-    }
 
     configureDisplay1();
 

--- a/example/demo2.cpp
+++ b/example/demo2.cpp
@@ -42,7 +42,7 @@ unsigned long long currentTimeMillis() {
 }
 
 
-void drawSine(Image image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
+void drawSine(Image &image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
     bool first = true;;
     int lx = -1, ly = -1;
     double vx = 0;
@@ -63,7 +63,7 @@ void drawSine(Image image, float offset, float speed, int maxX, int maxY, float 
 }
 
 
-bool demoSineWave(int frameCount, long long start, Image image) {
+bool demoSineWave(int frameCount, long long start, Image &image) {
     long long now = currentTimeMillis();
     float refVoltage = 5;
 

--- a/example/neopixel2.cpp
+++ b/example/neopixel2.cpp
@@ -73,7 +73,7 @@ unsigned long long currentTimeMillis() {
 }
 
 
-void drawSine(Image image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
+void drawSine(Image &image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
     bool first = true;
     int lx = -1, ly = -1;
     double vx = 0;
@@ -94,7 +94,7 @@ void drawSine(Image image, float offset, float speed, int maxX, int maxY, float 
 }
 
 
-bool demoSineWave(int frameCount, long long start, Image image) {
+bool demoSineWave(int frameCount, long long start, Image &image) {
     long long now = currentTimeMillis();
     float refVoltage = 5;
 

--- a/example/wsePaperV2.cpp
+++ b/example/wsePaperV2.cpp
@@ -39,7 +39,7 @@ unsigned long long currentTimeMillis() {
 }
 
 
-void drawSine(Image image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
+void drawSine(Image &image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
     bool first = true;;
     int lx = -1, ly = -1;
     double vx = 0;
@@ -60,7 +60,7 @@ void drawSine(Image image, float offset, float speed, int maxX, int maxY, float 
 }
 
 
-bool demoSineWave(int frameCount, long long start, Image image) {
+bool demoSineWave(int frameCount, long long start, Image &image) {
     long long now = currentTimeMillis();
     float refVoltage = 5;
 

--- a/src/controller/Color.cpp
+++ b/src/controller/Color.cpp
@@ -1,6 +1,6 @@
 #include "Color.h"
 #include <string.h>
-#include <stdio.h>
+#include <stdio.h> 
 
 Color::Color() {
     color.red = 0;
@@ -9,22 +9,22 @@ Color::Color() {
     color.opacity = 255;
 }
 
-
 Color::Color(ColorType color) {
-    this->color.red = color.red;
-    this->color.green = color.green;
-    this->color.blue = color.blue;
-    this->color.opacity = color.opacity;
+    setColor(color.red, color.green, color.blue, color.opacity);
 }
-
 
 Color::Color(_byte red, _byte green, _byte blue) {
-    color.red = red;
-    color.green = green;
-    color.blue = blue;
-    color.opacity = 255;
+    setColor(red, green, blue, 255);
 }
 
+Color::Color(_byte red, _byte green, _byte blue, _byte opacity) {
+    setColor(red, green, blue, opacity);
+}
+
+Color::Color(uint32_t colorRGB24) {
+    setRGB24(colorRGB24);
+}
+ 
 Color::Color(const char* hexbytes) {
     char buf[3];
     int intensity;
@@ -108,22 +108,19 @@ bool Color::equals(ColorType *otherColor) {
 }
 
 
-Color::Color(_byte red, _byte green, _byte blue, _byte opacity) {
-    color.red       = red;
-    color.green     = green;
-    color.blue      = blue;
-    color.opacity   = opacity;
+inline void Color::setColor(_byte red, _byte green, _byte blue, _byte opacity) {
+    color.red = red;
+    color.green = green;
+    color.blue = blue;
+    color.opacity = opacity;
 }
 
-ColorType Color::toType() {
-    return color;
+inline void Color::setRGB24(uint32_t colorRGB24) {
+    color.red = (_byte)(colorRGB24 & 0xFF);
+    color.green = (_byte)((colorRGB24 & 0xFF00) >> 8);
+    color.blue = (_byte)((colorRGB24 & 0xFF0000) >> 16);
+    color.opacity = (_byte)((colorRGB24 & 0xFF000000) >> 24);
 }
-
-
-int32_t Color::rgb24() {
-    return (color.green<<16)+(color.red<<8)+(color.blue);
-}
-
 
 Color::Color(int clr) {
     color.opacity = 255;

--- a/src/controller/Color.h
+++ b/src/controller/Color.h
@@ -12,6 +12,9 @@ struct ColorStruct {
 
 typedef ColorStruct ColorType;
 
+inline uint32_t   getRGB24(const ColorType *color) {
+   return (color->opacity << 24 ) | (color->blue << 16) | (color->green << 8) | color->red;
+}
 
 class Color {
 public:
@@ -19,14 +22,17 @@ public:
 
     Color();
     Color(ColorType color);
-    Color(_byte red, _byte blue, _byte green);
+    Color(_byte red, _byte green, _byte blue);
+    Color(_byte red, _byte green, _byte blue, _byte opacity);
+    Color(uint32_t colorRGB24);
     Color(const char *hexbytes);
-    Color(_byte red, _byte blue, _byte green, _byte opacity);
-
+ 
     Color(int pos);
 
-    ColorType toType();
-    int32_t   rgb24();
+    inline ColorType toType() { return color; }
+    inline uint32_t rgb24() { return getRGB24(&color); }
+    inline void setColor(_byte red, _byte green, _byte blue, _byte opacity);
+    inline void setRGB24(uint32_t colorRGB24);
     void      print();
     bool      equals(Color otherColor);
     bool      equals(ColorType otherColor);

--- a/src/controller/Image.h
+++ b/src/controller/Image.h
@@ -17,6 +17,8 @@ namespace udd {
     class Image {
     public:
         Image();
+        Image(const Image &img);
+        virtual ~Image();
         
         Image(int width, int height, Color backgroundColor);
 
@@ -51,9 +53,14 @@ namespace udd {
         void drawPieSlice(int x, int y, int radius, float degree1, float degree2, Color color, LineStyle style, int width);
         void printPixel(int x, int y);
 
-        ColorType* getPixel(int x, int y, udd::Rotation rotation);
+        ColorType* getPixel(int x, int y, udd::Rotation rotation) const;
 
-        ColorType* getPixelColor(int x, int y);
+        ColorType* getPixelColor(int x, int y) const;
+
+        Image scale(float scaleX, float scaleY, ScaleMode mode);
+
+    private:
+        static void scaleBilinear(const Image &src, Image &dst);
 
         
     private:
@@ -64,6 +71,6 @@ namespace udd {
         Color    backgroundColor;
 
         _word color2word(ColorType* xp);
-
+        void init();
     };
 }

--- a/src/controller/Metadata.h
+++ b/src/controller/Metadata.h
@@ -36,6 +36,8 @@ namespace udd {
         MASK
     } FillPattern;
 
-
+    typedef enum {
+        BILINEAR
+    } ScaleMode;
 
 }

--- a/src/displays/DisplayNeoPixel.cpp
+++ b/src/displays/DisplayNeoPixel.cpp
@@ -56,7 +56,7 @@ namespace udd {
         render(config.screenRotation);
     }
 
-    void DisplayNeoPixel::showImage(Image image, Rotation rotation, ScreenMirror mirror) {
+    void DisplayNeoPixel::showImage(Image &image, Rotation rotation, ScreenMirror mirror) {
 
         int row=0;
         int pos=0;
@@ -104,12 +104,12 @@ namespace udd {
     }
 
 
-    void DisplayNeoPixel::showImage(Image image, Rotation rotation) {
+    void DisplayNeoPixel::showImage(Image &image, Rotation rotation) {
         showImage(image, rotation, config.screenMirror);
     }
 
 
-    void DisplayNeoPixel::showImage(Image image) {
+    void DisplayNeoPixel::showImage(Image &image) {
         showImage(image, config.screenRotation, config.screenMirror);
     }
 

--- a/src/displays/DisplayNeoPixel.h
+++ b/src/displays/DisplayNeoPixel.h
@@ -32,9 +32,9 @@ namespace udd {
 
         void clearScreen(Color color);
 
-        void showImage(Image image, Rotation rotation, ScreenMirror mirror);
-        void showImage(Image image, Rotation rotation);
-        void showImage(Image image);
+        void showImage(Image &image, Rotation rotation, ScreenMirror mirror);
+        void showImage(Image &image, Rotation rotation);
+        void showImage(Image &image);
         void setPixel(Pixel pixel);
 
     private:


### PR DESCRIPTION
This commit adds bilinear interpolation scaling methods to `Image`. In the process, several issues with `Image` were found & fixed:

* There was no destructor to free the `canvas` memory. This would cause a memory leak unless the client remembered to call `close()` A virtual destructor has been added to free this memory.

* There was no explicit copy constructor for `Image` This means whenever Image was copied or passed by value a 'shallow copy' was performed resulting in both instances referencing the same shared canvas memory. This works, and several examples were depending on it, but after the addition of the destructor it caused seg faults since the memory was free()'d several times. An explicit copy constuctor for `Image` has been added to perform a 'deep copy' of the `canvas` memory.

* Several examples and the `DisplayNeoPixel::showImage()` methods were passing `Image` instances by value. This is now inefficient due to the deep copy. Since pass-by-reference semantics are required in these cases they are now passed by reference.

* New c'tors and getters added to `Color` to support RGBA access as required by the new scaling method on `Image` Also tidied up c'tors to use common helper methods.

* Used new/delete instead of malloc/free for heap memory use  in `Image` Just coz it's more conventional in C++