### PR TITLE
Fixes & improvements to Image, including scaling & arbitrary rotation.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -168,22 +168,22 @@ package() {
     ls -tr $LIB/* 2>/dev/null | tail -1 | grep '\.a' > /dev/null
     A=$?
 
-    echo Buliding source for dynamic library for sake of size and compatibility
+    echo Building source for dynamic library for sake of size and compatibility
     DYNAMIC="-fPIC"
     [ $A = 0 ] && clean objects
     build
 
-    echo Packagiang lib$LIBNAME.so
+    echo Packaging lib$LIBNAME.so
     OBJECTS=$(find $OBJ -type f)
     ${CC} -shared -Wl,-soname,lib$LIBNAME.so -o $LIB/lib$LIBNAME.so.$VERSION ${OBJECTS}  || die
     clean objects
   fi
 
-  echo Buliding source for static library for sake of runtime speed
+  echo Building source for static library for sake of runtime speed
   DYNAMIC=""
   build
 
-  echo Packagiang lib$LIBNAME.a
+  echo Packaging lib$LIBNAME.a
   OBJECTS=$(find $OBJ -type f)
   ar rcs $LIB/lib$LIBNAME.a $OBJECTS || die
   ranlib $LIB/lib$LIBNAME.a  || die

--- a/example/demo1.cpp
+++ b/example/demo1.cpp
@@ -19,7 +19,7 @@ $ g++ -lwiringPi -lwiringPiUDDrpi demo1.cpp -o demo1
 
 using namespace udd;
 
-DisplayConfigruation d1Config;
+DisplayConfiguration d1Config;
 
 DisplayST7789R d1 = DisplayST7789R();
 

--- a/example/demo1.cpp
+++ b/example/demo1.cpp
@@ -41,7 +41,7 @@ unsigned long long currentTimeMillis() {
 }
 
 
-void drawSine(Image image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
+void drawSine(Image &image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
     bool first = true;;
     int lx = -1, ly = -1;
     double vx = 0;
@@ -62,7 +62,7 @@ void drawSine(Image image, float offset, float speed, int maxX, int maxY, float 
 }
 
 
-bool demoSineWave(int frameCount, long long start, Image image) {
+bool demoSineWave(int frameCount, long long start, Image &image) {
     long long now = currentTimeMillis();
     float refVoltage = 5;
 
@@ -148,6 +148,29 @@ void rotationDemo() {
 
 }
 
+void imageRotationDemo(Image &img) {
+    Image srcImg = img.scale(0.75f, 0.75f, BILINEAR);
+    for (int deg = 0; deg < 360; deg += 5) {
+        printf("Rotate: %d degrees CW\n", deg);  fflush(stdout);
+        d1.showImage(srcImg.rotate(deg, DEGREES), DEGREE_270);
+    }
+    for (int deg = 0; deg > -360; deg -= 5) {
+        printf("Rotate: %d degrees CCW\n", deg);  fflush(stdout);
+        d1.showImage(srcImg.rotate(deg, DEGREES), DEGREE_270);
+    }
+}
+
+void imageScalingDemo(Image &img) {
+    for (int i = 100; i > 0; i -= 10) {
+        float scale = i / 100.0f;
+        d1.showImage(img.scale(scale, scale, BILINEAR), DEGREE_270);
+    }
+    for (int i = 20; i <= 200; i += 10) {
+        float scale = i / 100.0f;
+        d1.showImage(img.scale(scale, scale, BILINEAR), DEGREE_270);
+    }
+}
+
 void display1Demo() {
     printf("demo1\n"); fflush(stdout);
 
@@ -170,8 +193,8 @@ void display1Demo() {
         delay(solidsDelay);
         d1.clearScreen(BLACK);
 
-        d1.showImage(bmp, DEGREE_270);
-        delay(2000);
+        imageRotationDemo(bmp);
+        imageScalingDemo(bmp);
 
         rotationDemo();
         delay(4000);
@@ -189,6 +212,7 @@ void configureDisplay1() {
     d1Config.width = 240;
     d1Config.height = 320;
     d1Config.spiSpeed = spiSpeed;
+    d1Config.spiMode = 0;
 
     d1Config.CS = 21;
     d1Config.DC = 22;
@@ -214,14 +238,6 @@ int main(int argc, char **argv)
     pinMode(11, OUTPUT);
     digitalWrite(10, HIGH);
     digitalWrite(11, HIGH);
-
-    int         demos = 3;
-    pthread_t   threads[demos];
-    char        message[demos][256];
-
-    for (int i = 0; i < demos; ++i) {
-        sprintf(message[i], "demo thread %d", i);
-    }
 
     configureDisplay1();
 

--- a/example/demo2.cpp
+++ b/example/demo2.cpp
@@ -20,8 +20,8 @@ $ g++ -lwiringPi -lpthread 2displays.cpp /usr/local/lib/libwiringPiUDDrpi.a -o d
 
 using namespace udd;
 
-DisplayConfigruation d1Config;
-DisplayConfigruation d2Config;
+DisplayConfiguration d1Config;
+DisplayConfiguration d2Config;
 
 DisplayST7789R d1 = DisplayST7789R();
 DisplayST7735R d2 = DisplayST7735R();

--- a/example/demo2.cpp
+++ b/example/demo2.cpp
@@ -42,7 +42,7 @@ unsigned long long currentTimeMillis() {
 }
 
 
-void drawSine(Image image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
+void drawSine(Image &image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
     bool first = true;;
     int lx = -1, ly = -1;
     double vx = 0;
@@ -63,7 +63,7 @@ void drawSine(Image image, float offset, float speed, int maxX, int maxY, float 
 }
 
 
-bool demoSineWave(int frameCount, long long start, Image image) {
+bool demoSineWave(int frameCount, long long start, Image &image) {
     long long now = currentTimeMillis();
     float refVoltage = 5;
 

--- a/example/neopixel.cpp
+++ b/example/neopixel.cpp
@@ -23,7 +23,7 @@ https://www.amazon.com/gp/product/B01MCUOD8N
 
 using namespace udd;
 
-DisplayConfigruation d1Config;
+DisplayConfiguration d1Config;
 
 DisplayNeoPixel d1 = DisplayNeoPixel();
 

--- a/example/neopixel2.cpp
+++ b/example/neopixel2.cpp
@@ -44,7 +44,7 @@ Here is the layout:
 
 using namespace udd;
 
-DisplayConfigruation d1Config;
+DisplayConfiguration d1Config;
 
 DisplayNeoPixel d1 = DisplayNeoPixel();
 

--- a/example/neopixel2.cpp
+++ b/example/neopixel2.cpp
@@ -73,7 +73,7 @@ unsigned long long currentTimeMillis() {
 }
 
 
-void drawSine(Image image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
+void drawSine(Image &image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
     bool first = true;
     int lx = -1, ly = -1;
     double vx = 0;
@@ -94,7 +94,7 @@ void drawSine(Image image, float offset, float speed, int maxX, int maxY, float 
 }
 
 
-bool demoSineWave(int frameCount, long long start, Image image) {
+bool demoSineWave(int frameCount, long long start, Image &image) {
     long long now = currentTimeMillis();
     float refVoltage = 5;
 
@@ -394,7 +394,7 @@ void* setBrightness(void *) {
 
     int startTime=currentTimeMillis();
     for (int i=0;i<4;++i) {
-      float v=readVoltage(handle, i, 0);
+      float v=readVoltage(handle);
       if (v>6) {
         v=0;
       }

--- a/example/wsePaperV2.cpp
+++ b/example/wsePaperV2.cpp
@@ -19,7 +19,7 @@ $ g++ -lwiringPi -lwiringPiUDDrpi ws.ePaper-2.9b-v2.cpp -o ws.ePaper-2.9b-v2
 
 using namespace udd;
 
-DisplayConfigruation d1Config;
+DisplayConfiguration d1Config;
 
 DisplayWS_ePaper_v2 d1 = DisplayWS_ePaper_v2();
 

--- a/example/wsePaperV2.cpp
+++ b/example/wsePaperV2.cpp
@@ -39,7 +39,7 @@ unsigned long long currentTimeMillis() {
 }
 
 
-void drawSine(Image image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
+void drawSine(Image &image, float offset, float speed, int maxX, int maxY, float waveHeight, Color color, int width) {
     bool first = true;;
     int lx = -1, ly = -1;
     double vx = 0;
@@ -60,7 +60,7 @@ void drawSine(Image image, float offset, float speed, int maxX, int maxY, float 
 }
 
 
-bool demoSineWave(int frameCount, long long start, Image image) {
+bool demoSineWave(int frameCount, long long start, Image &image) {
     long long now = currentTimeMillis();
     float refVoltage = 5;
 

--- a/src/controller/Color.cpp
+++ b/src/controller/Color.cpp
@@ -9,22 +9,22 @@ Color::Color() {
     color.opacity = 255;
 }
 
-
 Color::Color(ColorType color) {
-    this->color.red = color.red;
-    this->color.green = color.green;
-    this->color.blue = color.blue;
-    this->color.opacity = color.opacity;
+    memcpy(&this->color, &color, sizeof(ColorType));
 }
-
 
 Color::Color(_byte red, _byte green, _byte blue) {
-    color.red = red;
-    color.green = green;
-    color.blue = blue;
-    color.opacity = 255;
+    setColor(red, green, blue, 255);
 }
 
+Color::Color(_byte red, _byte green, _byte blue, _byte opacity) {
+    setColor(red, green, blue, opacity);
+}
+
+Color::Color(uint32_t colorRGB24) {
+    setRGB24(colorRGB24);
+}
+ 
 Color::Color(const char* hexbytes) {
     char buf[3];
     int intensity;
@@ -68,62 +68,36 @@ Color::Color(const char* hexbytes) {
     }
 }
 
-bool Color::equals(Color otherColor) {
-    if (this->color.blue != otherColor.color.blue) {
+bool Color::equals(const Color &otherColor) const {
+    return equals(otherColor.color);
+}
+
+bool Color::equals(const ColorType &otherColor) const {
+    if (color.blue != otherColor.blue) {
         return false;
     }
-    if (this->color.red!= otherColor.color.red) {
+    if (color.red != otherColor.red) {
         return false;
     }
-    if (this->color.green != otherColor.color.green) {
+    if (color.green != otherColor.green) {
         return false;
     }
     return true;
 }
 
-bool Color::equals(ColorType otherColor) {
-    if (this->color.blue != otherColor.blue) {
-        return false;
-    }
-    if (this->color.red != otherColor.red) {
-        return false;
-    }
-    if (this->color.green != otherColor.green) {
-        return false;
-    }
-    return true;
+inline void Color::setColor(_byte red, _byte green, _byte blue, _byte opacity) {
+    color.red = red;
+    color.green = green;
+    color.blue = blue;
+    color.opacity = opacity;
 }
 
-bool Color::equals(ColorType *otherColor) {
-    if (this->color.blue != otherColor->blue) {
-        return false;
-    }
-    if (this->color.red != otherColor->red) {
-        return false;
-    }
-    if (this->color.green != otherColor->green) {
-        return false;
-    }
-    return true;
+inline void Color::setRGB24(uint32_t colorRGB24) {
+    color.red = (_byte)(colorRGB24 & 0xFF);
+    color.green = (_byte)((colorRGB24 & 0xFF00) >> 8);
+    color.blue = (_byte)((colorRGB24 & 0xFF0000) >> 16);
+    color.opacity = (_byte)((colorRGB24 & 0xFF000000) >> 24);
 }
-
-
-Color::Color(_byte red, _byte green, _byte blue, _byte opacity) {
-    color.red       = red;
-    color.green     = green;
-    color.blue      = blue;
-    color.opacity   = opacity;
-}
-
-ColorType Color::toType() {
-    return color;
-}
-
-
-int32_t Color::rgb24() {
-    return (color.green<<16)+(color.red<<8)+(color.blue);
-}
-
 
 Color::Color(int clr) {
     color.opacity = 255;
@@ -150,7 +124,7 @@ Color::Color(int clr) {
 }
 
 
-void Color::print() {
+void Color::print() const {
 
     printf("color::print: 0x%02x%02x%02x\n", this->color.red, this->color.blue,this->color.green);
     printf("color::print: 0x%02x%02x%02x\n", color.red, color.blue, color.green);
@@ -164,26 +138,26 @@ void Color::print() {
 
 
 // Original 8
-Color BLACK             = Color(0,     0,   0);
-Color RED               = Color(255,   0,   0);
-Color GREEN             = Color(0,   255,   0);
-Color BLUE              = Color(0,     0, 255);
-Color YELLOW            = Color(255, 255,   0);
-Color MAGENTA           = Color(255,   0, 255);
-Color CYAN              = Color(0,   255, 255);
-Color WHITE             = Color(255, 255, 255);
+const Color BLACK             = Color(0,     0,   0);
+const Color RED               = Color(255,   0,   0);
+const Color GREEN             = Color(0,   255,   0);
+const Color BLUE              = Color(0,     0, 255);
+const Color YELLOW            = Color(255, 255,   0);
+const Color MAGENTA           = Color(255,   0, 255);
+const Color CYAN              = Color(0,   255, 255);
+const Color WHITE             = Color(255, 255, 255);
 
 // extended colors
-Color GRAY              = Color("#808080");
-Color BROWN             = Color(165,  42,  42);
-Color ORANGE            = Color(255, 128,   0);
+const Color GRAY              = Color("#808080");
+const Color BROWN             = Color(165,  42,  42);
+const Color ORANGE            = Color(255, 128,   0);
 
-Color DARK_RED          = Color(128,   0,   0);
-Color DARK_GREEN        = Color(0,   128,   0);
-Color DARK_BLUE         = Color(0,     0, 128);
+const Color DARK_RED          = Color(128,   0,   0);
+const Color DARK_GREEN        = Color(0,   128,   0);
+const Color DARK_BLUE         = Color(0,     0, 128);
 
 
-Color LIGHT_BLUE        = Color(204, 228, 255);
-Color LIGHT_GRAY        = Color("#E0E0E0");
+const Color LIGHT_BLUE        = Color(204, 228, 255);
+const Color LIGHT_GRAY        = Color("#E0E0E0");
 
-Color DARK_GRAY_BLUE    = Color("003366");
+const Color DARK_GRAY_BLUE    = Color("003366");

--- a/src/controller/Color.h
+++ b/src/controller/Color.h
@@ -12,6 +12,9 @@ struct ColorStruct {
 
 typedef ColorStruct ColorType;
 
+inline uint32_t   getRGB24(const ColorType *color) {
+   return (color->opacity << 24 ) | (color->blue << 16) | (color->green << 8) | color->red;
+}
 
 class Color {
 public:
@@ -19,42 +22,44 @@ public:
 
     Color();
     Color(ColorType color);
-    Color(_byte red, _byte blue, _byte green);
+    Color(_byte red, _byte green, _byte blue);
+    Color(_byte red, _byte green, _byte blue, _byte opacity);
+    Color(uint32_t colorRGB24);
     Color(const char *hexbytes);
-    Color(_byte red, _byte blue, _byte green, _byte opacity);
-
+ 
     Color(int pos);
 
-    ColorType toType();
-    int32_t   rgb24();
-    void      print();
-    bool      equals(Color otherColor);
-    bool      equals(ColorType otherColor);
-    bool      equals(ColorType *otherColor);
+    inline ColorType toType() const { return color; }
+    inline uint32_t rgb24() const { return getRGB24(&color); }
+    inline void setColor(_byte red, _byte green, _byte blue, _byte opacity);
+    inline void setRGB24(uint32_t colorRGB24);
+    void      print() const;
+    bool      equals(const Color &otherColor) const;
+    bool      equals(const ColorType &otherColor) const;
 
 };
 
 
 // original 8
-extern Color BLACK;
-extern Color RED;
-extern Color GREEN;
-extern Color BLUE;
-extern Color YELLOW;
-extern Color MAGENTA;
-extern Color CYAN;
-extern Color WHITE;
+extern const Color BLACK;
+extern const Color RED;
+extern const Color GREEN;
+extern const Color BLUE;
+extern const Color YELLOW;
+extern const Color MAGENTA;
+extern const Color CYAN;
+extern const Color WHITE;
 
-extern Color GRAY;
-extern Color BROWN;
-extern Color ORANGE;
+extern const Color GRAY;
+extern const Color BROWN;
+extern const Color ORANGE;
 
-extern Color LIGHT_BLUE;
-extern Color LIGHT_GRAY;
+extern const Color LIGHT_BLUE;
+extern const Color LIGHT_GRAY;
 
-extern Color DARK_BLUE;
-extern Color DARK_RED;
-extern Color DARK_GREEN;
+extern const Color DARK_BLUE;
+extern const Color DARK_RED;
+extern const Color DARK_GREEN;
 
-extern Color DARK_GRAY_BLUE;
+extern const Color DARK_GRAY_BLUE;
 

--- a/src/controller/Display.cpp
+++ b/src/controller/Display.cpp
@@ -43,7 +43,7 @@ namespace udd {
 
 
 
-    void Display::openDisplay(DisplayConfigruation configuration) {
+    void Display::openDisplay(DisplayConfiguration configuration) {
         this->config = configuration;
 //        this->vImage = Image(config.width, config.height, BLACK);
 

--- a/src/controller/Display.cpp
+++ b/src/controller/Display.cpp
@@ -138,7 +138,7 @@ namespace udd {
         }
     }
 
-    void Display::clearWindow(Color color, Point p1, Point p2, Rotation rotation) {
+    void Display::clearWindow(const Color &color, Point p1, Point p2, Rotation rotation) {
         screenLock.lock();
 
         openSPI();
@@ -168,7 +168,7 @@ namespace udd {
         screenLock.unlock();
     }
 
-    void Display::clearScreen(Color color) {
+    void Display::clearScreen(const Color &color) {
         screenLock.lock();
         openSPI();
         resume();
@@ -204,11 +204,11 @@ namespace udd {
     }
 
 
-    void Display::showImage(Image& image) {
+    void Display::showImage(const Image& image) {
         showImage(image, Point(0,0), Point(config.width-1, config.height-1), DEGREE_0);
     }
 
-    void Display::showImage(Image& image, Rotation rotation) {
+    void Display::showImage(const Image& image, Rotation rotation) {
         Point p1 = Point(0, 0);
         Point p2 = Point(config.width-1, config.height-1);
 
@@ -218,7 +218,7 @@ namespace udd {
         showImage(image, p1, p2, rotation);
     }
     
-    void Display::showImage(Image& image, Point p1, Point p2, Rotation rotation) {
+    void Display::showImage(const Image& image, Point p1, Point p2, Rotation rotation) {
         int width, height;
         screenLock.lock();
         openSPI();
@@ -232,8 +232,8 @@ namespace udd {
 
         if (image.getHeight() != height ||
             image.getWidth() != width) {
-            fprintf(stderr, "Image size does not match window size. Height: [Image=%d, Window=%d]   Width: [Image=%d, Window=%d]\n",
-                image.getHeight(), height, image.getWidth(), width);
+            fprintf(stderr, "Image size does not match window size. Image: (%dx%d)  Window: (%dx%d)\n",
+                image.getWidth(), image.getHeight(), width, height);
         }
 
 

--- a/src/controller/Display.h
+++ b/src/controller/Display.h
@@ -50,7 +50,7 @@ namespace udd {
         int brightness;
     };
 
-    typedef DisplayConfigurationStruct      DisplayConfigruation;
+    typedef DisplayConfigurationStruct      DisplayConfiguration;
 
     Rotation validateRotation(char* rotation);
 
@@ -67,12 +67,12 @@ namespace udd {
         virtual void setWindow(Point p1, Point p2, Rotation rotation);
 
     public:
-        DisplayConfigruation config;
+        DisplayConfiguration config;
         
         virtual void init();
 
 
-        void openDisplay(DisplayConfigruation configuratrion);
+        void openDisplay(DisplayConfiguration configuratrion);
 
         
         virtual void clearScreen(const Color &color);

--- a/src/controller/Display.h
+++ b/src/controller/Display.h
@@ -75,12 +75,12 @@ namespace udd {
         void openDisplay(DisplayConfigruation configuratrion);
 
         
-        virtual void clearScreen(Color color);
-        virtual void clearWindow(Color color, Point p1, Point p2, Rotation rotation);
+        virtual void clearScreen(const Color &color);
+        virtual void clearWindow(const Color &color, Point p1, Point p2, Rotation rotation);
         
-        virtual void showImage(Image& image);
-        virtual void showImage(Image& image, Rotation rotation);
-        virtual void showImage(Image& image, Point p1, Point p2, Rotation rotation);
+        virtual void showImage(const Image& image);
+        virtual void showImage(const Image& image, Rotation rotation);
+        virtual void showImage(const Image& image, Point p1, Point p2, Rotation rotation);
 
         virtual void readBusy() {
             fprintf(stderr, "readBusy() is not implemented for this method\n");

--- a/src/controller/Image.h
+++ b/src/controller/Image.h
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <Color.h>
+#include "Color.h"
 #include "inttypes.h"
 #include "fonts.h"
 
@@ -17,43 +17,57 @@ namespace udd {
     class Image {
     public:
         Image();
+        Image(const Image &img);
+        Image(Image &&img);
+        Image& operator=(const Image &img);
+        Image& operator=(Image &&img);
+        virtual ~Image();
         
-        Image(int width, int height, Color backgroundColor);
+        Image(int width, int height, const Color &backgroundColor);
 
-        int getWidth();
-        int getHeight();
+        int getWidth() const;
+        int getHeight() const;
 
-        void clear(Color backgroundColor);
+        void clear(const Color &backgroundColor);
 
         void close();
 
-        void drawPixel(int x, int y, Color color);
+        void drawPixel(int x, int y, const Color &color);
+        void drawPixel(int x, int y, const ColorType &color);
 
-        void drawLine(int x1, int y1, int x2, int y2, Color color, LineStyle style, int width);
-        void drawLineArc(int x, int y, int radius, float degree, Color color, LineStyle style, int width);
+        void drawLine(int x1, int y1, int x2, int y2, const Color &color, LineStyle style, int width);
+        void drawLineArc(int x, int y, int radius, float degree, const Color &color, LineStyle style, int width);
 
-        void drawPoint(int x, int y, Color color, int width);
+        void drawPoint(int x, int y, const Color &color, int width);
 
         void drawText(int Xstart, int Ystart, const char* pString,
-            sFONT* Font, Color background, Color forground);
+            sFONT* Font, const Color &background, const Color &forground);
 
-        void drawChar(int Xpoint, int Ypoint, const char Acsii_Char, sFONT* Font, Color Color_Background, Color Color_Foreground);
+        void drawChar(int Xpoint, int Ypoint, const char Acsii_Char, sFONT* Font, const Color &Color_Background, const Color &Color_Foreground);
 
         void loadBMP(FILE* file, int Xstart, int Ystart);
 
         void loadBMP(const char* filename, int Xstart, int Ystart);
 
-        void drawRectangle(int x1, int y1, int x2, int y2, Color Color, FillPattern pattern, LineStyle lineStyle, int width);
+        void drawRectangle(int x1, int y1, int x2, int y2, const Color &Color, FillPattern pattern, LineStyle lineStyle, int width);
 
         void arcPoint(int x, int y, int length, double degree, int* xPoint, int* yPoint);
 
-        void drawCircle(int x, int y, int radius, Color Color, FillPattern pattern, LineStyle lineStyle, int width);
-        void drawPieSlice(int x, int y, int radius, float degree1, float degree2, Color color, LineStyle style, int width);
+        void drawCircle(int x, int y, int radius, const Color &Color, FillPattern pattern, LineStyle lineStyle, int width);
+        void drawPieSlice(int x, int y, int radius, float degree1, float degree2, const Color &color, LineStyle style, int width);
         void printPixel(int x, int y);
 
-        ColorType* getPixel(int x, int y, udd::Rotation rotation);
+        ColorType* getPixel(int x, int y, udd::Rotation rotation) const;
 
-        ColorType* getPixelColor(int x, int y);
+        ColorType* getPixelColor(int x, int y) const;
+
+        Image scale(float scaleX, float scaleY, ScaleMode mode);
+        Image rotate(float angle, AngleUnit units);
+
+    private:
+        static void scaleBilinear(const Image &src, Image &dst);
+        Image simpleRotate(udd::Rotation rotation);
+        Image threeShearRotate(float angleRads);
 
         
     private:
@@ -64,6 +78,7 @@ namespace udd {
         Color    backgroundColor;
 
         _word color2word(ColorType* xp);
-
+        void init();
+        void copy(const Image& img);
     };
 }

--- a/src/controller/Metadata.h
+++ b/src/controller/Metadata.h
@@ -36,6 +36,13 @@ namespace udd {
         MASK
     } FillPattern;
 
+    typedef enum {
+        BILINEAR
+    } ScaleMode;
 
+    typedef enum {
+        DEGREES,
+        RADIANS
+    } AngleUnit;
 
 }

--- a/src/displays/DisplayNeoPixel.cpp
+++ b/src/displays/DisplayNeoPixel.cpp
@@ -46,7 +46,7 @@ namespace udd {
         this->vImage.drawPoint(pixel.point.x, pixel.point.y, pixel.color, 1);
     }
 
-    void DisplayNeoPixel::clearScreen(Color color) {
+    void DisplayNeoPixel::clearScreen(const Color &color) {
 
         for (int x=0;x<config.width;++x) {
             for (int y=0;y<config.height;++y) {
@@ -56,7 +56,7 @@ namespace udd {
         render(config.screenRotation);
     }
 
-    void DisplayNeoPixel::showImage(Image image, Rotation rotation, ScreenMirror mirror) {
+    void DisplayNeoPixel::showImage(const Image &image, Rotation rotation, ScreenMirror mirror) {
 
         int row=0;
         int pos=0;
@@ -104,12 +104,12 @@ namespace udd {
     }
 
 
-    void DisplayNeoPixel::showImage(Image image, Rotation rotation) {
+    void DisplayNeoPixel::showImage(const Image &image, Rotation rotation) {
         showImage(image, rotation, config.screenMirror);
     }
 
 
-    void DisplayNeoPixel::showImage(Image image) {
+    void DisplayNeoPixel::showImage(const Image &image) {
         showImage(image, config.screenRotation, config.screenMirror);
     }
 

--- a/src/displays/DisplayNeoPixel.cpp
+++ b/src/displays/DisplayNeoPixel.cpp
@@ -5,7 +5,7 @@ namespace udd {
 
     DisplayNeoPixel::DisplayNeoPixel() : Display() {}
 
-    void DisplayNeoPixel::openDisplay(DisplayConfigruation configuration) {
+    void DisplayNeoPixel::openDisplay(DisplayConfiguration configuration) {
         this->config = configuration;
         this->vImage = Image(config.width, config.height, BLACK);
 

--- a/src/displays/DisplayNeoPixel.h
+++ b/src/displays/DisplayNeoPixel.h
@@ -22,7 +22,7 @@ namespace udd {
     public:
 
         DisplayNeoPixel();
-        void openDisplay(DisplayConfigruation configuration);
+        void openDisplay(DisplayConfiguration configuration);
         void printConfiguration();
         void setBrightness(int brightness);
         void render(Rotation rotation);

--- a/src/displays/DisplayNeoPixel.h
+++ b/src/displays/DisplayNeoPixel.h
@@ -30,11 +30,11 @@ namespace udd {
         void addGhostPixel(Point point);
         void addGhostPixels(std::vector<Point> points);
 
-        void clearScreen(Color color);
+        void clearScreen(const Color &color);
 
-        void showImage(Image image, Rotation rotation, ScreenMirror mirror);
-        void showImage(Image image, Rotation rotation);
-        void showImage(Image image);
+        void showImage(const Image &image, Rotation rotation, ScreenMirror mirror);
+        void showImage(const Image &image, Rotation rotation);
+        void showImage(const Image &image);
         void setPixel(Pixel pixel);
 
     private:

--- a/src/displays/DisplayWS_ePaper_v2.cpp
+++ b/src/displays/DisplayWS_ePaper_v2.cpp
@@ -96,7 +96,7 @@ namespace udd {
     }
 
     
-    void DisplayWS_ePaper_v2::clearScreen(Color color) {
+    void DisplayWS_ePaper_v2::clearScreen(const Color &color) {
         screenLock.lock();
 
         openSPI();
@@ -167,16 +167,16 @@ namespace udd {
         }
     }
 
-    void DisplayWS_ePaper_v2::showImage(Image& image) {
+    void DisplayWS_ePaper_v2::showImage(const Image& image) {
         Display::showImage(image);
     }
 
-    void DisplayWS_ePaper_v2::showImage(Image& image, Rotation rotation) {
+    void DisplayWS_ePaper_v2::showImage(const Image& image, Rotation rotation) {
         Display::showImage(image, rotation);
     }
 
 
-    void DisplayWS_ePaper_v2::showImage(Image &image, Point p1, Point p2, Rotation rotation) {
+    void DisplayWS_ePaper_v2::showImage(const Image &image, Point p1, Point p2, Rotation rotation) {
 
         fprintf(stderr, "ePaper showImage(%d,%d)\n", config.width, config.height);
 
@@ -198,13 +198,13 @@ namespace udd {
                 ColorType* ct = image.getPixel(x - config.xOffset, y - config.yOffset, rotation);
                 int val=1;
                 if (ct != NULL) {
-                    if (WHITE.equals(ct)) {
+                    if (WHITE.equals(*ct)) {
                         val=1;
                     }
-                    else if (BLACK.equals(ct)) {
+                    else if (BLACK.equals(*ct)) {
                         val=0;
                     }
-                    else if (RED.equals(ct)) {
+                    else if (RED.equals(*ct)) {
                         val=1;
                     } else {
                         fprintf(stderr, "invalid color found at (%d,%d)\n", x, y);
@@ -232,13 +232,13 @@ namespace udd {
                 ColorType* ct = image.getPixel(x - config.xOffset, y - config.yOffset, rotation);
                 int val=1;
                 if (ct != NULL) {
-                    if (WHITE.equals(ct)) {
+                    if (WHITE.equals(*ct)) {
                         val=1;
                     }
-                    else if (BLACK.equals(ct)) {
+                    else if (BLACK.equals(*ct)) {
                         val=1;
                     }
-                    else if (RED.equals(ct)) {
+                    else if (RED.equals(*ct)) {
                         val=0;
                     } else {
                         fprintf(stderr, "invalid color found at (%d,%d)\n", x, y);

--- a/src/displays/DisplayWS_ePaper_v2.h
+++ b/src/displays/DisplayWS_ePaper_v2.h
@@ -16,10 +16,10 @@ namespace udd {
         void initPartial();
         void reset() override;
         void readBusy() override;
-        void clearScreen(Color color) override;
-        void showImage(Image& image) override;
-        void showImage(Image& image, Rotation rotation) override;
-        void showImage(Image& image, Point p1, Point p2, Rotation rotation) override;
+        void clearScreen(const Color &color) override;
+        void showImage(const Image& image) override;
+        void showImage(const Image& image, Rotation rotation) override;
+        void showImage(const Image& image, Point p1, Point p2, Rotation rotation) override;
         void EPD_SetFullReg();
         void setPartReg();
         void enableDisplay();


### PR DESCRIPTION
This commit adds bilinear interpolation scaling and arbirary rotation methods to `Image`.
In the process, several issues with `Image` were found & fixed:

* There was no destructor to free the `canvas` memory. This would cause a memory leak unless the client remembered to call `close()` A virtual destructor has been added to free this memory.

* There was no explicit copy & move constructor for `Image` This means whenever Image was copied or passed by value a 'shallow copy' was performed resulting in both instances referencing the same shared canvas memory. This works, and several examples were depending on it, but after the addition of the destructor it caused seg faults since the memory was free()'d several times. An explicit copy constuctor for `Image` has been added to perform a 'deep copy' of the `canvas` memory. A C++11 'move' constructor has been added to avoid excessive deep copies being made when passing `Image` as a temporary.

* The same logic for copy/move constructors also applies to assignment operators (operator=()) so these are added.

* `Image` (and `Color`) are extensively passed by value within the library. This now potentially inefficient due to the deep copy. (if the move c'tor is not used) Since pass-by-reference semantics are required in these cases they are now passed by reference.

* Pass-by-(const)-reference changes also required many methods on `Image` and `Color` that did not modify their members to be declared `const` as well as all `Color` preset constants.

* New c'tors and getters added to `Color` to support RGBA access as required by the new scaling method on `Image` Also tidied up c'tors to use common helper methods.

* Used new/delete instead of malloc/free for heap memory use  in `Image` Just coz it's more conventional in C++